### PR TITLE
Task 1.2a: Docker Setup Only

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,38 @@ Open [http://localhost:3000](http://localhost:3000) with your browser to see the
 
 You can start editing the page by modifying `app/page.tsx`. The page auto-updates as you edit the file.
 
+## Docker Setup
+
+This project uses Docker for PostgreSQL and Redis. To start the services:
+
+```bash
+docker compose up -d
+```
+
+**Note: Non-standard ports are used to avoid conflicts:**
+- PostgreSQL: Port `5434` (instead of default 5432)
+- Redis: Port `6380` (instead of default 6379)
+
+### Docker Commands
+
+```bash
+# Start services
+docker compose up -d
+
+# Check service health
+docker compose ps
+
+# Test connections
+./test-docker.sh
+
+# View logs
+docker compose logs postgres
+docker compose logs redis
+
+# Stop services
+docker compose down
+```
+
 This project uses [`next/font`](https://nextjs.org/docs/app/building-your-application/optimizing/fonts) to automatically optimize and load [Geist](https://vercel.com/font), a new font family for Vercel.
 
 ## Learn More

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3.8'
 services:
   postgres:
     image: postgres:15
@@ -7,7 +6,7 @@ services:
       POSTGRES_PASSWORD: aiemailpass
       POSTGRES_DB: aiemaildb
     ports:
-      - "5432:5432"
+      - "5434:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:
@@ -19,7 +18,7 @@ services:
   redis:
     image: redis:7
     ports:
-      - "6379:6379"
+      - "6380:6379"
     volumes:
       - redis_data:/data
     healthcheck:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,33 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:15
+    environment:
+      POSTGRES_USER: aiemailuser
+      POSTGRES_PASSWORD: aiemailpass
+      POSTGRES_DB: aiemaildb
+    ports:
+      - "5432:5432"
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U aiemailuser"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/test-docker.sh
+++ b/test-docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+echo "Testing PostgreSQL connection..."
+docker exec test-repo-postgres-1 pg_isready -U aiemailuser
+
+echo "Testing Redis connection..."
+docker exec test-repo-redis-1 redis-cli ping


### PR DESCRIPTION
## Summary
Completed Task 1.2a - Set up Docker containers for PostgreSQL and Redis.

## Changes
- Created docker-compose.yml with PostgreSQL 15 and Redis 7
- Configured persistent volumes and health checks for both services
- Created .env.docker with environment variables
- Created test-docker.sh script to verify connections
- Updated README with Docker setup instructions

## Important Notes
- PostgreSQL runs on port **5434** (instead of default 5432)
- Redis runs on port **6380** (instead of default 6379)
- Ports were changed to avoid conflicts with existing services

## Validation Results
All acceptance criteria have been met:
- ✅ docker-compose.yml created with PostgreSQL and Redis services
- ✅ Containers start successfully with `docker compose up -d`
- ✅ Health checks pass for both services
- ✅ Data persists across container restarts (volumes configured)
- ✅ Connection test script confirms both services are accessible

## Testing
```bash
docker compose up -d     # Services start successfully
docker compose ps        # Both containers show as healthy
./test-docker.sh        # Connections verified (PostgreSQL + Redis)
docker compose logs      # No critical errors
```

Closes #37